### PR TITLE
Add infra.sh commands for deploys for jinja and docker

### DIFF
--- a/infra.sh
+++ b/infra.sh
@@ -2,6 +2,9 @@ VM_NAME=cromwell
 
 DB_INSTANCE=cromwell1
 DEPLOY_NAME=cromwell
+DOCKER_IMAGE=jackmaruska/cloudize-workflow
+
+SRC_DIR="$(dirname "${BASH_SOURCE[0]}")"
 
 case $1 in
     "start")
@@ -15,5 +18,25 @@ case $1 in
         gcloud compute instances stop $VM_NAME
         echo "Stopping database $DB_INSTANCE"
         gcloud sql instances patch $DB_INSTANCE --activation-policy NEVER
+        ;;
+    "create-deploy")
+        echo "Creating new deployment"
+        gcloud deployment-manager deployments create $DEPLOY_NAME --config $SRC_DIR/jinja/deployment.yaml
+        ;;
+    "update-deploy")
+        echo "Updating previous deployment"
+        gcloud deployment-manager deployments update $DEPLOY_NAME --config $SRC_DIR/jinja/deployment.yaml
+        ;;
+    "build-and-tag")
+        echo "Building container image tagged latest"
+        docker build $SRC_DIR/scripts/ -t $DOCKER_IMAGE:latest
+        # this one will be cached, basically just doing a tag without having to find image ID
+        echo "Building container image tagged $2"
+        docker build $SRC_DIR/scripts/ -t $DOCKER_IMAGE:$2
+
+        echo "Pushing container image tagged latest"
+        docker push $DOCKER_IMAGE:latest
+        echo "Pushing container image tagged $2"
+        docker push $DOCKER_IMAGE:$2
         ;;
 esac

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -3,3 +3,4 @@ FROM python:3.8
 COPY requirements.txt /opt/requirements.txt
 RUN pip3 install -r /opt/requirements.txt
 COPY cloudize-workflow.py /opt/cloudize-workflow.py
+COPY pull_outputs.py /opt/pull_outputs.py


### PR DESCRIPTION
- Add command to create a new google deployment for jinja-owned compute VM
- Add command to update a previous google deployment for jinja-owned compute VM
- Add command to build-and-tag a docker container image 