### PR TITLE
Log info for missing values instead of showing errors.

### DIFF
--- a/scripts/pull_outputs.py
+++ b/scripts/pull_outputs.py
@@ -42,6 +42,8 @@ def download(path, value, subdir = None):
             logging.warning(f"Likely not a File output. had a non-GCS path value of {value}")
         else:
             download_from_gcs(value, Path(f"{path}/{Path(value).name}"))
+    elif value is None:
+        logging.info(f"Skipping optional output that wasn't defined{': ' + subdir if subdir else ''}")
     else:
         logging.error(f"Don't know how to download type {type(value)}. Full object: {value}")
 


### PR DESCRIPTION
If an optional output had no value (i.e., was `null` in the JSON), then we'd see this error:
```
[ERROR] Don't know how to download type <class 'NoneType'>. Full object: None
```
Now instead this case will log an info message like:
```
[INFO] Skipping optional output that wasn't defined: some_optional_value
```