### PR TITLE
added ability to specify what version of cloud-workflows to pull

### DIFF
--- a/manual-workflows/server_startup.py
+++ b/manual-workflows/server_startup.py
@@ -89,7 +89,10 @@ def download_from_metadata(tag, dest_path):
 def clone_analysis_wdls():
     old_dir = os.getcwd()
     os.chdir(SHARED_DIR)
-    status_code = os.system('git clone https://github.com/griffithlab/analysis-wdls.git')
+    release = _fetch_instance_info('analysis-release')
+    print(f"git clone https://github.com/wustl-oncology/analysis-wdls.git --branch v{release}")
+
+    status_code = os.system(f"git clone https://github.com/wustl-oncology/analysis-wdls.git --branch v{release}")
     os.chdir(old_dir)
     if status_code != 0:
         raise Exception("Clone failed for griffithlab/analysis-wdls")

--- a/manual-workflows/start.sh
+++ b/manual-workflows/start.sh
@@ -18,6 +18,7 @@ arguments:
 --workflow-options   Local path to workflow_options.json. DEFAULT \$SRC_DIR/workflow_options.json
 --machine-type       GCP machine type for the instance. DEFAULT e2-standard-2
 --zone               DEFAULT us-central1-c. For options, visit: https://cloud.google.com/compute/docs/regions-zones 
+--analysis-release   DEFAULT 1.1.4. For options, visit: https://github.com/wustl-oncology/analysis-wdls/releases
 
 Additional arguments are passed directly to gsutil compute instances
 create command. For more information on those arguments, check that commands
@@ -91,9 +92,17 @@ while test $# -gt 0; do
             ;;
         --zone*)
             if [ ! "$2" ]; then
-		ZONE="us-central1-c"
+		        ZONE="us-central1-c"
             else
                 ZONE=$2
+                shift
+            fi
+            ;;
+        --analysis-release*)
+            if [ ! "$2" ]; then
+                ANALYSIS_RELEASE="1.1.4"
+            else
+                ANALYSIS_RELEASE=$2
                 shift
             fi
             ;;
@@ -111,6 +120,7 @@ MACHINE_TYPE=${MACHINE_TYPE:-"e2-standard-2"}
 [ -z $CROMWELL_CONF    ] && CROMWELL_CONF="$SRC_DIR/cromwell.conf"
 [ -z $WORKFLOW_OPTIONS ] && WORKFLOW_OPTIONS="$SRC_DIR/workflow_options.json"
 [ -z $ZONE             ] && ZONE="us-central1-c"
+[ -z $ANALYSIS_RELEASE ] && ANALYSIS_RELEASE="1.1.4"
 
 if [[ ! -f $CROMWELL_CONF ]]; then
     cat <<EOF
@@ -142,7 +152,7 @@ gcloud compute instances create $INSTANCE_NAME \
        --machine-type=$MACHINE_TYPE \
        --service-account=$SERVER_ACCOUNT --scopes=cloud-platform \
        --network=$NETWORK --subnet=$SUBNET \
-       --metadata=cromwell-version=71 \
+       --metadata=cromwell-version=71,analysis-release="$ANALYSIS_RELEASE" \
        --metadata-from-file=startup-script=$SRC_DIR/server_startup.py,cromwell-conf=$CROMWELL_CONF,helpers-sh=$SRC_DIR/helpers.sh,cromwell-service=$SRC_DIR/cromwell.service,workflow-options=$WORKFLOW_OPTIONS,persist-artifacts=$SRC_DIR/../scripts/persist_artifacts.py \
        $@
 


### PR DESCRIPTION
To address this [issue](https://github.com/wustl-oncology/cloud-workflows/issues/37) I have changed the default version of cloud-workflows pulled to be v1.1.4. As @tmooney has suggested there is also an ability for the user to choose what version to use. An example of the command looks like:

`bash start.sh $GCS_INSTANCE_NAME --server-account $GCS_SERVICE_ACCOUNT --project $GCS_PROJECT --analysis-release=1.1.3`

This was done by passing another key-value pair in the metadata parameter of the `gcloud compute instances create` command. 