### PR TITLE
Tweaks for building against the newer google base image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ ADD manual-workflows/server_startup.py /opt/manual-workflows/server_startup.py
 ADD manual-workflows/start.sh /opt/manual-workflows/start.sh
 ADD manual-workflows/cromwell.service /opt/manual-workflows/cromwell.service
 
-RUN pip3 install -r /opt/scripts/requirements.txt
+RUN pip3 install --no-build-isolation --break-system-packages -r /opt/scripts/requirements.txt

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,5 @@
+cython<3.0.0
+
 cwl_utils
 miniwdl == 1.2.1
 


### PR DESCRIPTION
* Python tries to protect you, but that's less useful in a docker image.
* Incorporate workaround suggestion from yaml/pyyaml#724.