### PR TITLE
Fixed 'gb_estimate_billing' script error

### DIFF
--- a/scripts/gb_estimate_billing.py
+++ b/scripts/gb_estimate_billing.py
@@ -69,9 +69,7 @@ def get_calls(metadata):
 
 
 def is_cached_task(call):
-    if CACHED_KEY in call:
-        return call[CACHED_KEY]["hit"] == True
-    return False
+    return call.get(CACHED_KEY, {}).get("hit") is True
 
 
 def is_subworkflow(call):
@@ -79,7 +77,7 @@ def is_subworkflow(call):
 
 
 def is_task_completed(call):
-    return call[COMPLETED_TASK_KEY] == "Done"
+    return call[COMPLETED_TASK_KEY] == "Done" or call["backendStatus"] == "Preempted"
 
 
 def convert_from_iso(datetime_str):


### PR DESCRIPTION
Malachi was experiencing an error with the cost estimation script described [here](https://github.com/wustl-oncology/cloud-workflows/issues/43). I resolved the issue by adding support for when the `CACHED_KEY` is present but the `hit` key is not.