### PR TITLE
Modified scripts to handle both GCS and local paths

### DIFF
--- a/scripts/persist_artifacts.py
+++ b/scripts/persist_artifacts.py
@@ -8,7 +8,9 @@ from argparse import ArgumentParser
 from pathlib import Path
 
 CROMWELL_API = "http://localhost:8000/api"
-LOCAL_DIR=os.environ["HOME"] + "/artifacts"
+#LOCAL_DIR=os.environ["HOME"] + "/artifacts"
+#LOCAL_DIR=Path("/storage1/fs1/mgriffit/Active/griffithlab/gc2596/j.yao/immuno_local_copy_output/test_files/pvacseq_test/temp/artifacts")
+# workflow_id="33773f84-1655-43b2-b2aa-a56b6cae52b5"
 
 
 def _request_workflow(endpoint):
@@ -23,10 +25,28 @@ def _save_locally(contents, filename):
     with open(target, 'w') as f:
         f.write(contents)
 
-
-def persist_artifacts_to_gcs(gcs_artifacts_dir):
-    logging.info(f"Copying {LOCAL_DIR} to {gcs_artifacts_dir}")
-    os.system(f"gsutil -q cp -r -n {LOCAL_DIR} {gcs_artifacts_dir}")
+# TODO: make an if condition to check if we are working locally on storage1 or on GCS
+# maybe GCS directories start with gs:// and local ones with /scratch1/...
+# old function: 
+#def persist_artifacts_to_gcs(gcs_artifacts_dir):
+    #logging.info(f"Copying {LOCAL_DIR} to {gcs_artifacts_dir}")
+    #os.system(f"gsutil -q cp -r -n {LOCAL_DIR} {gcs_artifacts_dir}")
+# new function to handle both GCS and local directories
+def persist_artifacts(artifacts_dir):
+    """
+    Persist artifacts to either Google Cloud Storage (if gcs_artifacts_dir starts with 'gs://')
+    or to a local directory (if it does not start with 'gs://').
+    """
+    if artifacts_dir.startswith("gs://"):
+        # Handle Google Cloud Storage
+        logging.info(f"Copying {LOCAL_DIR} to Google Cloud Storage at {artifacts_dir}")
+        os.system(f"gsutil -q cp -r -n {LOCAL_DIR} {artifacts_dir}")
+    else:
+        # Handle local directory
+        logging.info(f"Copying {LOCAL_DIR} to local directory at {artifacts_dir}")
+        os.makedirs(artifacts_dir, exist_ok=True)  # Ensure the target directory exists
+        os.system(f"cp -r {LOCAL_DIR}/* {artifacts_dir}")
+        
 
 
 def json_str(obj):
@@ -127,9 +147,18 @@ def fetch_all_timing(metadata_by_workflow_id):
 
 if __name__ == "__main__":
     parser = ArgumentParser(description="Upload Cromwell endpoint responses for a given workflow. Uploads timing, outputs, and metadata (including subworkflow metadata).")
-    parser.add_argument("gcs_dir")
+    parser.add_argument("artifacts_dir")
     parser.add_argument("workflow_id")
     args = parser.parse_args()
+
+    # NEW
+    # Dynamically define LOCAL_DIR based on artifacts_dir
+    if args.artifacts_dir.startswith("gs://"):
+        LOCAL_DIR = os.environ["HOME"] + "/artifacts"
+    else:
+        LOCAL_DIR = Path(os.getcwd()) / "artifacts"
+    # Ensure the directory exists
+    LOCAL_DIR.mkdir(parents=True, exist_ok=True)
 
     log_level = os.environ.get("LOGLEVEL", "INFO").upper()
     logging.basicConfig(
@@ -137,14 +166,17 @@ if __name__ == "__main__":
         format='[%(levelname)s] %(message)s'
     )
 
-    metadata_by_workflow_id = fetch_metadata(args.workflow_id)
+    metadata_by_workflow_id = fetch_metadata(args.workflow_id) 
+    # metadata_by_workflow_id = fetch_metadata(workflow_id)
     timing_by_workflow_id = fetch_all_timing(metadata_by_workflow_id)
 
     # Save root with special names for easy access
     root_metadata = metadata_by_workflow_id[args.workflow_id]
+    #root_metadata = metadata_by_workflow_id[workflow_id]
     _save_locally(json_str(root_metadata), 'metadata.json')
 
     root_timing   = timing_by_workflow_id[args.workflow_id]
+    #root_timing   = timing_by_workflow_id[workflow_id]
     _save_locally(root_timing,   'timing.html')
 
     root_outputs  = {"outputs": root_metadata["outputs"]}
@@ -162,4 +194,6 @@ if __name__ == "__main__":
     for workflow_id, timing in timing_by_workflow_id.items():
         _save_locally(timing, f"timing/{workflow_id}.html")
 
-    persist_artifacts_to_gcs(args.gcs_dir)
+    #persist_artifacts_to_gcs(args.gcs_dir)
+    # update function to handle both GCS and local directories
+    persist_artifacts(args.artifacts_dir)

--- a/scripts/pull_outputs.py
+++ b/scripts/pull_outputs.py
@@ -12,24 +12,69 @@ DEFAULT_DRYRUN = False
 
 DRYRUN = DEFAULT_DRYRUN
 
-
-def download_from_gcs(src, dest):
-    "Copy a GCS file at path `src` to local path `dest`, creating that path if needed."
-    os.makedirs(Path(dest).parent, exist_ok=True)
-    if not Path(dest).is_file():
-        logging.info(f"Downloading {src} to {dest}")
+# Update this function to handel both local and GCS paths
+# old function
+#def download_from_gcs(src, dest):
+    #"Copy a GCS file at path `src` to local path `dest`, creating that path if needed."
+    #os.makedirs(Path(dest).parent, exist_ok=True)
+    #if not Path(dest).is_file():
+        #logging.info(f"Downloading {src} to {dest}")
+        #if not DRYRUN:
+            #subprocess.call(['gsutil', '-q', 'cp', '-n', src, dest])
+    #else:
+        #logging.info(f"File already exists, skipping download {src} to {dest}")
+# new function
+def download_file(src, dest):
+    """
+    Copy a file from `src` to `dest`. 
+    - If `src` starts with "gs://", it uses `gsutil` to copy the file from Google Cloud Storage.
+    - If `src` is a local path, it uses the `cp` command to copy the file locally.
+    """
+    os.makedirs(Path(dest).parent, exist_ok=True)  # Ensure the destination directory exists
+    if not Path(dest).is_file():  # Check if the file already exists
+        logging.info(f"Copying {src} to {dest}")
         if not DRYRUN:
-            subprocess.call(['gsutil', '-q', 'cp', '-n', src, dest])
+            if src.startswith("gs://"):
+                # Use gsutil for Google Cloud Storage paths
+                subprocess.call(['gsutil', '-q', 'cp', '-n', src, dest])
+            else:
+                # Use cp for local paths
+                subprocess.call(['cp', src, dest])
     else:
-        logging.info(f"File already exists, skipping download {src} to {dest}")
+        logging.info(f"File already exists, skipping copy {src} to {dest}")
 
+# old function
+#def download(path, value, subdir = None):
+#    """
+#    Recursively download all output files.
+#    GCS file `value` will be downloaded under `path
+#    `subdir` is an optional value _only_ for types which need a directory, e.g. lists + dicts
+#    If `subdir` is specified, list/dict types will download under `path/subdir`
+#    """
+#    if isinstance(value, list):
+#        for loc in value:
+#            download(f"{Path(path)}/{subdir or ''}", loc)
+#    elif isinstance(value, dict):
+#        for k, v in value.items():
+#            download(f"{path}/{subdir or ''}", v, subdir=k)
+#    elif isinstance(value, str):
+#        if not value.startswith("gs://"):
+#            logging.warning(f"Likely not a File output. had a non-GCS path value of {value}")
+#        else:
+#            download_from_gcs(value, Path(f"{path}/{Path(value).name}"))
+#    elif value is None:
+#        logging.info(f"Skipping optional output that wasn't defined{': ' + subdir if subdir else ''}")
+#    else:
+#        logging.error(f"Don't know how to download type {type(value)}. Full object: {value}")
 
-def download(path, value, subdir = None):
+# new function: 
+def download(path, value, subdir=None):
     """
     Recursively download all output files.
-    GCS file `value` will be downloaded under `path
-    `subdir` is an optional value _only_ for types which need a directory, e.g. lists + dicts
-    If `subdir` is specified, list/dict types will download under `path/subdir`
+    - If `value` is a GCS file (starts with "gs://"), it will be downloaded using `download_file`.
+    - If `value` is a local file, it will also be handled by `download_file`.
+    - `subdir` is an optional value _only_ for types which need a directory, e.g., lists and dicts.
+    If `subdir` is specified, list/dict types will download under `path/subdir`.
     """
     if isinstance(value, list):
         for loc in value:
@@ -38,10 +83,8 @@ def download(path, value, subdir = None):
         for k, v in value.items():
             download(f"{path}/{subdir or ''}", v, subdir=k)
     elif isinstance(value, str):
-        if not value.startswith("gs://"):
-            logging.warning(f"Likely not a File output. had a non-GCS path value of {value}")
-        else:
-            download_from_gcs(value, Path(f"{path}/{Path(value).name}"))
+        # Handle both GCS and local paths
+        download_file(value, Path(f"{path}/{Path(value).name}"))
     elif value is None:
         logging.info(f"Skipping optional output that wasn't defined{': ' + subdir if subdir else ''}")
     else:
@@ -63,7 +106,8 @@ def read_json(filename):
     if filename.startswith("gs://"):
         tmpdir = os.environ.get("TMPDIR", "/tmp")
         tmpfile = f"{Path(tmpdir)}/{Path(filename).name}"
-        download_from_gcs(filename, tmpfile)
+        #download_from_gcs(filename, tmpfile)
+        download_file(filename, tmpfile)
         with open(tmpfile) as f:
             return json.load(f)
     else:
@@ -84,6 +128,8 @@ if __name__ == "__main__":
                         help=f"Skips the actual download and just prints progress info. Useful for troubleshooting the script.")
     args = parser.parse_args()
 
+    # outputs_file="/storage1/fs1/mgriffit/Active/griffithlab/gc2596/j.yao/immuno_local_copy_output/test_files/pvacseq_test/test_persist_artifacts/workflow_artifacts/outputs.json"
+    # outputs_dir="/storage1/fs1/mgriffit/Active/griffithlab/gc2596/j.yao/immuno_local_copy_output/test_files/pvacseq_test/test_pull_outputs"
     DRYRUN = args.dryrun
     outputs_dir = args.outputs_dir
 
@@ -93,4 +139,5 @@ if __name__ == "__main__":
         format='[%(levelname)s] %(message)s'
     )
 
+    # download_outputs(read_json(outputs_file), outputs_dir)
     download_outputs(read_json(args.outputs_file), outputs_dir)


### PR DESCRIPTION
We would like replicate how the Google cloud workflow copies and organizes pipeline outputs on RIS. 
The following scripts were modified to now also work with storage1 file paths: 

-  persist_artifacts.py
- pull_outputs.py

The usage of these script when running the cloud workflow should still stay the same. 