### PR TITLE
add validate_immuno_yaml.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get install -y zip
 ADD scripts/cloudize-workflow.py /opt/scripts/cloudize-workflow.py
 ADD scripts/pull_outputs.py /opt/scripts/pull_outputs.py
 ADD scripts/requirements.txt /opt/scripts/requirements.txt
+ADD scripts/validate_immuno_yaml.py /opt/scripts/validate_immuno_yaml.py
 
 # Submit workflows
 ADD scripts/submit_workflow.sh /opt/scripts/submit_workflow.sh

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -8,6 +8,7 @@ ruamel.yaml >= 0.15.0
 
 pathlib == 1.0.1
 
+PyYAML
 
 # do not use google-cloud-storage
 # it requires a service-account setup instead of personal creds

--- a/scripts/validate_immuno_yaml.py
+++ b/scripts/validate_immuno_yaml.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+
+import os
+import yaml
+import subprocess
+import argparse
+import re
+
+def is_gs_path(path):
+    return path.startswith("gs://")
+
+def file_exists(path):
+    if is_gs_path(path):
+        try:
+            subprocess.check_call(["gsutil", "-q", "stat", path], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            return True
+        except subprocess.CalledProcessError:
+            return False
+    elif path.startswith("/"):
+        return os.path.exists(path)
+    return False
+
+def flatten_file_paths(yaml_dict):
+    paths = []
+
+    def recurse(obj):
+        if isinstance(obj, dict):
+            for v in obj.values():
+                recurse(v)
+        elif isinstance(obj, list):
+            for item in obj:
+                recurse(item)
+        elif isinstance(obj, str) and (obj.startswith("gs://") or obj.startswith("/")):
+            paths.append(obj)
+
+    recurse(yaml_dict)
+    return paths
+
+def extract_rg_field(readgroup_str, field):
+    pattern = fr"{field}:([^\t\\]+)"
+    match = re.search(pattern, readgroup_str)
+    return match.group(1) if match else None
+
+def check_commenting_issues(yaml_text):
+    lines = yaml_text.splitlines()
+    for i, line in enumerate(lines):
+        if re.match(r"#\s*immuno\.problematic_amino_acids\s*:", line):
+            j = i + 1
+            while j < len(lines) and not re.match(r"^\s*immuno\.", lines[j]):
+                if re.match(r"^\s*-\s+\S", lines[j]):
+                    print(f"Improperly commented list item after commented key on line {i+1}: '{lines[j].strip()}'")
+                    break
+                j += 1
+
+def check_empty_active_keys_with_commented_lists(yaml_text):
+    lines = yaml_text.splitlines()
+    for i, line in enumerate(lines):
+        if re.match(r"^\s*immuno\.\w+:\s*$", line):  # active key, no value
+            key_line = line.strip()
+            key_indent = len(line) - len(line.lstrip())
+            has_active_item = False
+            j = i + 1
+            while j < len(lines):
+                next_line = lines[j]
+                next_indent = len(next_line) - len(next_line.lstrip())
+                if next_indent <= key_indent and re.match(r"^\s*\w", next_line):
+                    break
+                if re.match(r"^\s*-\s+\S", next_line):  # active item
+                    has_active_item = True
+                    break
+                j += 1
+            if not has_active_item:
+                print(f"Key '{key_line}' appears active but has only commented-out list items (or none).")
+
+def is_proper_fastq_pair(fq1, fq2):
+    fq1_base = os.path.basename(fq1)
+    fq2_base = os.path.basename(fq2)
+    patterns = [
+        ("_1.fastq.gz", "_2.fastq.gz"),
+        ("_1.fq.gz", "_2.fq.gz"),
+        (".R1.fastq.gz", ".R2.fastq.gz"),
+        (".R1.fq.gz", ".R2.fq.gz"),
+        ("-1.fastq.gz", "-2.fastq.gz"),
+        ("-1.fq.gz", "-2.fq.gz"),
+    ]
+    for r1, r2 in patterns:
+        if fq1_base.endswith(r1) and fq2_base.endswith(r2):
+            if fq1_base.replace(r1, "") == fq2_base.replace(r2, ""):
+                return True
+    if fq1_base.replace("_1", "_2") == fq2_base:
+        return True
+    if fq1_base.replace("R1", "R2") == fq2_base:
+        return True
+    if fq1_base.replace("-1", "-2") == fq2_base:
+        return True
+    return False
+
+def validate_yaml(yaml_file):
+    print(f"Validating: {yaml_file}\n")
+
+    try:
+        with open(yaml_file) as f:
+            yaml_text = f.read()
+            data = yaml.safe_load(yaml_text)
+    except Exception as e:
+        print(f"Failed to read or parse YAML: {e}")
+        return
+
+    immuno = {k[len("immuno.") :]: v for k, v in data.items() if k.startswith("immuno.")}
+    if not immuno:
+        print("Error: No keys starting with 'immuno.' were found.")
+        return
+
+    print("Checking file paths...")
+    paths = flatten_file_paths(immuno)
+    missing = [p for p in paths if not file_exists(p)]
+    if missing:
+        print("Missing file paths:")
+        for p in missing:
+            print(f" - {p}")
+    else:
+        print("All file paths exist.")
+
+    print("\nChecking for duplicate file paths...")
+    duplicates = set([p for p in paths if paths.count(p) > 1])
+    if duplicates:
+        print("Duplicate file paths:")
+        for p in duplicates:
+            print(f" - {p}")
+    else:
+        print("No duplicate file paths found.")
+
+    print("\nChecking FASTQ pairings...")
+    for group in ['tumor_sequence', 'normal_sequence', 'rna_sequence']:
+        sequences = immuno.get(group, [])
+        for i, seq in enumerate(sequences):
+            s = seq["sequence"]
+            fq1, fq2 = s["fastq1"], s["fastq2"]
+            if not is_proper_fastq_pair(fq1, fq2):
+                print(f"Pairing mismatch in {group} entry {i+1}:")
+                print(f"   fastq1: {fq1}")
+                print(f"   fastq2: {fq2}")
+
+    print("\n👤 Checking readgroup SM fields...")
+    expected_sms = {
+        "tumor_sequence": immuno.get("tumor_sample_name"),
+        "normal_sequence": immuno.get("normal_sample_name"),
+        "rna_sequence": immuno.get("sample_name"),
+    }
+    for group, expected_sm in expected_sms.items():
+        sequences = immuno.get(group, [])
+        for i, seq in enumerate(sequences):
+            rg = seq["readgroup"]
+            actual_sm = extract_rg_field(rg, "SM")
+            if actual_sm != expected_sm:
+                print(f"SM mismatch in {group} entry {i+1}: expected '{expected_sm}', found '{actual_sm}'")
+
+    print("\nRNA CN fields:")
+    for seq in immuno.get("rna_sequence", []):
+        rg = seq["readgroup"]
+        cn = extract_rg_field(rg, "CN")
+        print(f" - CN: {cn}")
+    print(f"Strand: {immuno.get('strand')}")
+
+    print("\nChecking for improperly commented list items...")
+    check_commenting_issues(yaml_text)
+    check_empty_active_keys_with_commented_lists(yaml_text)
+
+    print("\nValidation complete.")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Validate an immuno YAML file for common formatting and logic errors.")
+    parser.add_argument("yaml_file", help="Path to the YAML file to validate.")
+    args = parser.parse_args()
+
+    validate_yaml(args.yaml_file)


### PR DESCRIPTION
This PR introduces a script to check input yamls for the immuno pipeline and attempts to address the following potential gotchas.

"To make it more generally applicable we'll write it in a way that for every file path, if the path starts with gs: it will use gsutil (to check paths), and if it starts with / it will check it 'locally'.

Common gotchas/ checks to add to the script-


Do all filepaths exist

Is there an R2 file for every R1 file (and vice versa)

No 2 filepaths are identical

The sample name in the readgroup (tSM:) matches the corresponding YAML sample_name field immuno.tumor_sample_name, immuno.normal_sample_name, etc.

Print out RNA readgroup CN field and immuno.strand
Potentially trickier to implement-


A way to check if inputs that should be skipped have been commented out properly. Eg: If immuno.problematic_amino_acids: and - C in the following line should be commented out, we should check that the variable immuno.problematic_amino_acids: has some text after it before we reach the next input (that should also start with immuno.). This doesn't check for a situation where immuno.problematic_amino_acids: was commented out but - C wasn't."