### PR TITLE
Tweaks to infra.sh for building docker images and error checking

### DIFF
--- a/infra.sh
+++ b/infra.sh
@@ -35,11 +35,8 @@ case $1 in
         ;;
     "build-and-tag")
         VERSION=$(head -n 1 "$SRC_DIR/VERSION")
-        echo "Building container image tagged latest"
-        docker build $SRC_DIR -t $DOCKER_IMAGE:latest
-        # this one will be cached, basically just doing a tag without having to find image ID
-        echo "Building container image tagged $VERSION"
-        docker build $SRC_DIR -t $DOCKER_IMAGE:$VERSION
+        echo "Building container image tagged latest and $VERSION"
+        docker build $SRC_DIR -t $DOCKER_IMAGE:latest -t $DOCKER_IMAGE:$VERSION
 
         echo "Pushing container image tagged latest"
         docker push $DOCKER_IMAGE:latest

--- a/infra.sh
+++ b/infra.sh
@@ -1,3 +1,6 @@
+set -o nounset
+set -o errexit
+
 VM_NAME=cromwell
 
 DB_INSTANCE=cromwell1


### PR DESCRIPTION
* Can tag the newly built image both ways at once.
* Some error checking (in case, say, the script fails to read into `$VERSION`).