### PR TITLE
Google cloud resources and versions updates

### DIFF
--- a/gms/resources.sh
+++ b/gms/resources.sh
@@ -79,7 +79,7 @@ cat <<EOF > lifecycle_rules.json
     ]
 }
 EOF
-gsutil lifecycle set lifecycle_rules.json gs://$BUCKET
+gcloud storage buckets update gs://$BUCKET --lifecycle-file=lifecycle_rules.json
 rm lifecycle_rules.json
 
 

--- a/gms/server_startup.py
+++ b/gms/server_startup.py
@@ -89,7 +89,7 @@ def download_from_metadata(tag, dest_path):
     """
     Download gs:// path from `tag` to `dest_path`. `tag` value expected to be a GCS path.
     """
-    os.system(f"gsutil cp {_fetch_instance_attribute(tag)} {dest_path}")
+    os.system(f"gcloud storage cp {_fetch_instance_attribute(tag)} {dest_path}")
 
 
 def _fetch_instance_metadata(path):
@@ -173,8 +173,8 @@ def persist_vm_logs(gcs_dir):
     """
     os.system('journalctl -u google-startup-scripts > vm.log')
     os.system('journalctl -u cromwell > cromwell.log')
-    os.system(f"gsutil cp vm.log {gcs_dir}/vm.log")
-    os.system(f"gsutil cp cromwell.log {gcs_dir}/cromwell.log")
+    os.system(f"gcloud storage cp vm.log {gcs_dir}/vm.log")
+    os.system(f"gcloud storage cp cromwell.log {gcs_dir}/cromwell.log")
 
 
 def persist_url_response(url, gcs_dir, filename):
@@ -186,7 +186,7 @@ def persist_url_response(url, gcs_dir, filename):
         logging.debug(f"Persisting {filename}")
         with open(filename, 'wb') as f:
             f.write(response.content)
-        os.system(f"gsutil cp {filename} {outdir}/{filename}")
+        os.system(f"gcloud storage cp {filename} {outdir}/{filename}")
     else:
         # TODO(john): troubleshooting info from response
         logging.error(f"Could not retrieve {filename} diagram. Please investigate")

--- a/manual-workflows/resources.sh
+++ b/manual-workflows/resources.sh
@@ -19,7 +19,7 @@ function show_help {
     echo "    --project      name of your GCP project"
     echo "    --ip-range     block/range of acceptable IPs e.g. 172.16.0.0/24 or a single IP address e.g. 172.16.5.9/32 or a comma-seperated list of IPs/CIDRs."
     echo "    --gc-region    DEFAULT='us-central1'. For other regions, check: https://cloud.google.com/compute/docs/regions-zones"
-    echo "    --retention    DEFAULT is none. For more option, check: https://cloud.google.com/storage/docs/gsutil/commands/mb#retention-policy"
+    echo "    --retention    DEFAULT is none. For more option, check: https://cloud.google.com/sdk/gcloud/reference/storage/buckets/create#--retention-period"
     echo ""
 }
 

--- a/manual-workflows/resources.sh
+++ b/manual-workflows/resources.sh
@@ -19,7 +19,7 @@ function show_help {
     echo "    --project      name of your GCP project"
     echo "    --ip-range     block/range of acceptable IPs e.g. 172.16.0.0/24 or a single IP address e.g. 172.16.5.9/32 or a comma-seperated list of IPs/CIDRs."
     echo "    --gc-region    DEFAULT='us-central1'. For other regions, check: https://cloud.google.com/compute/docs/regions-zones"
-    echo "    --retention    DEFAULT is none. For more option, check: https://cloud.google.com/sdk/gcloud/reference/storage/buckets/create#--retention-period"
+    echo "    --retention    DEFAULT is none. For more options, check: https://cloud.google.com/sdk/gcloud/reference/storage/buckets/create#--retention-period"
     echo ""
 }
 

--- a/manual-workflows/start.sh
+++ b/manual-workflows/start.sh
@@ -19,9 +19,10 @@ arguments:
 --machine-type       GCP machine type for the instance. DEFAULT e2-standard-2
 --zone               DEFAULT us-central1-c. For options, visit: https://cloud.google.com/compute/docs/regions-zones 
 --analysis-release   DEFAULT 1.7.0. For options, visit: https://github.com/wustl-oncology/analysis-wdls/releases
+--cromwell-version   DEFAULT 92. For options, visit: https://github.com/broadinstitute/cromwell/releases
 
-Additional arguments are passed directly to gsutil compute instances
-create command. For more information on those arguments, check that commands
+Additional arguments are passed directly to the gcloud compute instances
+create command. For more information on those arguments, check that command's
 help page with
 
     gcloud compute instances create --help
@@ -106,6 +107,14 @@ while test $# -gt 0; do
                 shift
             fi
             ;;
+        --cromwell-version*)
+            if [ ! "$2" ]; then
+                CROMWELL_VERSION="92"
+            else
+                CROMWELL_VERSION=$2
+                shift
+            fi
+            ;;
         *)
             break
             ;;
@@ -121,6 +130,7 @@ MACHINE_TYPE=${MACHINE_TYPE:-"e2-standard-2"}
 [ -z $WORKFLOW_OPTIONS ] && WORKFLOW_OPTIONS="$SRC_DIR/workflow_options.json"
 [ -z $ZONE             ] && ZONE="us-central1-c"
 [ -z $ANALYSIS_RELEASE ] && ANALYSIS_RELEASE="1.7.0"
+[ -z $CROMWELL_VERSION ] && CROMWELL_VERSION="92"
 
 if [[ ! -f $CROMWELL_CONF ]]; then
     cat <<EOF
@@ -152,7 +162,7 @@ gcloud compute instances create $INSTANCE_NAME \
        --machine-type=$MACHINE_TYPE \
        --service-account=$SERVER_ACCOUNT --scopes=cloud-platform \
        --network=$NETWORK --subnet=$SUBNET \
-       --metadata=cromwell-version=88,analysis-release="$ANALYSIS_RELEASE" \
+       --metadata=cromwell-version="$CROMWELL_VERSION",analysis-release="$ANALYSIS_RELEASE" \
        --metadata-from-file=startup-script=$SRC_DIR/server_startup.py,cromwell-conf=$CROMWELL_CONF,helpers-sh=$SRC_DIR/helpers.sh,cromwell-service=$SRC_DIR/cromwell.service,workflow-options=$WORKFLOW_OPTIONS,persist-artifacts=$SRC_DIR/../scripts/persist_artifacts.py \
        $@
 

--- a/manual-workflows/user_permissions.sh
+++ b/manual-workflows/user_permissions.sh
@@ -74,7 +74,7 @@ done
 
 case $COMMAND in
     "grant")
-        gsutil iam ch user:$EMAIL:objectAdmin gs://$BUCKET
+        gcloud storage buckets add-iam-policy-binding gs://$BUCKET --member=user:$EMAIL --role=roles/storage.objectAdmin
         gcloud projects add-iam-policy-binding $PROJECT \
                --member=user:$EMAIL \
                --role='roles/compute.instanceAdmin' > /dev/null
@@ -87,7 +87,7 @@ case $COMMAND in
         echo ""
         ;;
     "revoke")
-        gsutil iam ch -d user:$EMAIL gs://$BUCKET
+        gcloud storage buckets remove-iam-policy-binding gs://$BUCKET --member=user:$EMAIL --role=roles/storage.objectAdmin
         gcloud projects remove-iam-policy-binding $PROJECT \
                --member=user:$EMAIL \
                --role='roles/compute.instanceAdmin' > /dev/null

--- a/scripts/cloudize-workflow.py
+++ b/scripts/cloudize-workflow.py
@@ -282,7 +282,6 @@ def write_new_inputs(new_input_obj, output_path):
 
 def upload_all(file_inputs, bucket, dryrun):
     # Upload all the files
-    # TODO: find a way to optimize/parallelize (gcloud storage parallelizes by default,
     for f in file_inputs:
         for file_path in f.all_file_paths:
             upload_to_gcs(bucket, file_path.local, file_path.cloud, dryrun=dryrun)

--- a/scripts/cloudize-workflow.py
+++ b/scripts/cloudize-workflow.py
@@ -33,7 +33,7 @@ def upload_to_gcs(bucket, src, dest, dryrun=False):
     elif dryrun:
         pass
     else:
-        os.system(f"gsutil cp -n {src} {gcs_uri}")
+        os.system(f"gcloud storage cp --no-clobber {src} {gcs_uri}")
 
 
 # ---- Generic functions -----------------------------------------------
@@ -282,7 +282,7 @@ def write_new_inputs(new_input_obj, output_path):
 
 def upload_all(file_inputs, bucket, dryrun):
     # Upload all the files
-    # TODO: find a way to optimize/parallelize a la `gsutil -m
+    # TODO: find a way to optimize/parallelize (gcloud storage parallelizes by default,
     for f in file_inputs:
         for file_path in f.all_file_paths:
             upload_to_gcs(bucket, file_path.local, file_path.cloud, dryrun=dryrun)

--- a/scripts/create_resources.sh
+++ b/scripts/create_resources.sh
@@ -76,10 +76,13 @@ gcloud compute firewall-rules create $NETWORK-allow-ssh \
        --allow tcp:22
 
 # Bucket
-[ ! -z $RETENTION ] && gsutil mb --retention $RETENTION gs://$BUCKET
-gsutil mb -p $PROJECT -b on gs://$BUCKET
-gsutil iam ch serviceAccount:$COMPUTE_ACCOUNT:objectAdmin gs://$BUCKET
-gsutil iam ch serviceAccount:$COMPUTE_ACCOUNT:legacyBucketOwner gs://$BUCKET
-gsutil iam ch serviceAccount:$SERVER_ACCOUNT:objectAdmin gs://$BUCKET
-gsutil iam ch serviceAccount:$SERVER_ACCOUNT:legacyBucketOwner gs://$BUCKET
-gsutil pap set enforced gs://$BUCKET
+if [ ! -z $RETENTION ]; then
+    gcloud storage buckets create gs://$BUCKET --project=$PROJECT --location=$GC_REGION --uniform-bucket-level-access --retention-period=$RETENTION
+else
+    gcloud storage buckets create gs://$BUCKET --project=$PROJECT --location=$GC_REGION --uniform-bucket-level-access
+fi
+gcloud storage buckets add-iam-policy-binding gs://$BUCKET --member=serviceAccount:$COMPUTE_ACCOUNT --role=roles/storage.objectAdmin
+gcloud storage buckets add-iam-policy-binding gs://$BUCKET --member=serviceAccount:$COMPUTE_ACCOUNT --role=roles/storage.legacyBucketOwner
+gcloud storage buckets add-iam-policy-binding gs://$BUCKET --member=serviceAccount:$SERVER_ACCOUNT --role=roles/storage.objectAdmin
+gcloud storage buckets add-iam-policy-binding gs://$BUCKET --member=serviceAccount:$SERVER_ACCOUNT --role=roles/storage.legacyBucketOwner
+gcloud storage buckets update gs://$BUCKET --public-access-prevention

--- a/scripts/estimate_billing.py
+++ b/scripts/estimate_billing.py
@@ -55,7 +55,7 @@ def read_json(filename):
     if filename.startswith("gs://"):
         tmpdir = os.environ.get("TMPDIR", "/tmp")
         tmpfile = f"{Path(tmpdir)}/{Path(filename).name}"
-        subprocess.call(['gsutil', '-q', 'cp', '-n', filename, tmpfile])
+        subprocess.call(['gcloud', 'storage', 'cp', '--no-clobber', '--quiet', filename, tmpfile])
         with open(tmpfile) as f:
             return json.load(f)
     else:

--- a/scripts/gb_estimate_billing.py
+++ b/scripts/gb_estimate_billing.py
@@ -55,7 +55,7 @@ def load_metadata(metadata_dir, workflow_id):
     if path.startswith("gs://"):
         tmpdir = os.environ.get("TMPDIR", "/tmp")
         tmpfile = f"{Path(tmpdir)}/{Path(path).name}"
-        subprocess.call(['gsutil', '-q', 'cp', '-n', path, tmpfile])
+        subprocess.call(['gcloud', 'storage', 'cp', '--no-clobber', '--quiet', path, tmpfile])
         with open(tmpfile) as f:
             data = json.load(f)
     else:

--- a/scripts/persist_artifacts.py
+++ b/scripts/persist_artifacts.py
@@ -31,7 +31,7 @@ def persist_artifacts(artifacts_dir):
     if artifacts_dir.startswith("gs://"):
         # Handle Google Cloud Storage
         logging.info(f"Copying {LOCAL_DIR} to Google Cloud Storage at {artifacts_dir}")
-        os.system(f"gsutil -q cp -r -n {LOCAL_DIR} {artifacts_dir}")
+        os.system(f"gcloud storage cp --recursive --no-clobber --quiet {LOCAL_DIR} {artifacts_dir}")
     else:
         # Handle local directory
         logging.info(f"Copying {LOCAL_DIR} to local directory at {artifacts_dir}")

--- a/scripts/pull_outputs.py
+++ b/scripts/pull_outputs.py
@@ -16,7 +16,7 @@ DRYRUN = DEFAULT_DRYRUN
 def download_file(src, dest):
     """
     Copy a file from `src` to `dest`. 
-    - If `src` starts with "gs://", it uses `gsutil` to copy the file from Google Cloud Storage.
+    - If `src` starts with "gs://", it uses `gcloud storage` to copy the file from Google Cloud Storage.
     - If `src` is a local path, it uses the `cp` command to copy the file locally.
     """
     os.makedirs(Path(dest).parent, exist_ok=True)  # Ensure the destination directory exists
@@ -24,8 +24,8 @@ def download_file(src, dest):
         logging.info(f"Copying {src} to {dest}")
         if not DRYRUN:
             if src.startswith("gs://"):
-                # Use gsutil for Google Cloud Storage paths
-                subprocess.call(['gsutil', '-q', 'cp', '-n', src, dest])
+                # Use gcloud storage for Google Cloud Storage paths
+                subprocess.call(['gcloud', 'storage', 'cp', '--no-clobber', '--quiet', src, dest])
             else:
                 # Use cp for local paths
                 subprocess.call(['cp', src, dest])

--- a/scripts/validate_immuno_yaml.py
+++ b/scripts/validate_immuno_yaml.py
@@ -12,7 +12,7 @@ def is_gs_path(path):
 def file_exists(path):
     if is_gs_path(path):
         try:
-            subprocess.check_call(["gcloud", "storage", "objects", "describe", path], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            subprocess.check_call(["gcloud", "storage", "objects", "describe", path, "--format=none"], stderr=subprocess.DEVNULL)
             return True
         except subprocess.CalledProcessError:
             return False

--- a/scripts/validate_immuno_yaml.py
+++ b/scripts/validate_immuno_yaml.py
@@ -12,7 +12,7 @@ def is_gs_path(path):
 def file_exists(path):
     if is_gs_path(path):
         try:
-            subprocess.check_call(["gsutil", "-q", "stat", path], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            subprocess.check_call(["gcloud", "storage", "objects", "describe", path], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             return True
         except subprocess.CalledProcessError:
             return False


### PR DESCRIPTION
This PR fixes several issues related to running Cromwell/WDL pipelines on Google Cloud using GCP Batch

- When new google buckets are created during resource initialization, explicitly set the region to match the region where VMs will be launched (us-central1 by default).  This may result in performance and cost improvements.
- Migrate all commands that use `gsutil` to `gcloud` equivalents since `gsutil` is being phased out. This may also lead to some performance improvements, during provisioning and final results retrieval. It may also avoid future failures when `gsutil` is no longer supported
- Create an option for the user to supply the version of cromwell used when a Cromwell VM is set up.  Set the default to be the latest version (`92`) which effectively bumps the default (`88` -> `92`).  The Cromwell release notes suggest some improvements in recent releases specifically related to Google Batch support. 